### PR TITLE
Fix App import ordering

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -4,10 +4,10 @@ import type { OnMount } from '@monaco-editor/react'
 import { useAtom, useSetAtom } from 'jotai'
 import { useEffect, useRef, useState } from 'react'
 import type * as Tone from 'tone'
+import { z, ZodError } from 'zod/v4'
 
 import { execFromEditor, PLUGINS } from '../lang/evaluate'
-import type { Track } from '../ostinato'
-import { Engine } from '../ostinato'
+import { Engine, type Track } from '../ostinato'
 import type { EditorLanguage } from './components/Editor'
 import Editor from './components/Editor'
 import Header from './components/Header'
@@ -19,15 +19,13 @@ import { Toaster } from './components/shadcn-ui/toaster'
 import defaultPkl from './default_pkl.txt?raw'
 import defaultPython from './default_python.py?raw'
 import defaultTs from './default_ts.ts?raw'
-import { getSamples, type SampleDetails } from './load_samples'
-import { loadSample } from './load_samples'
+import { getSamples, loadSample, type SampleDetails } from './load_samples'
 import {
   currentBeatAtom,
   editorLanguageAtom,
   evaluatingStatusIndicatorAtom,
   schedulingStatusIndicatorAtom,
 } from './state'
-import { ZodError, z } from 'zod/v4'
 
 const App = () => {
   const [engineState, setEngine] = useState<Engine | null>(null)


### PR DESCRIPTION
## Summary
- sort the imports in `src/ui/App.tsx` so they satisfy the `simple-import-sort` rule
- consolidate the `../ostinato` and `./load_samples` imports to keep related symbols grouped

## Testing
- npx eslint src/ui/App.tsx

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919c3e4fa3c8329b3683de4cf57a7eb)